### PR TITLE
Update install documentation with latest APT key guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Install Acton via this apt repository:
 ```sh
-wget -q -O - https://apt.acton-lang.io/acton.gpg | sudo apt-key add -
-echo "deb http://apt.acton-lang.io/ bullseye main" | sudo tee /etc/apt/sources.list.d/acton.list
-sudo apt-get update
-sudo apt-get install -qy acton
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
+sudo chmod a+r /etc/apt/keyrings/acton.asc
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee -a /etc/apt/sources.list.d/acton.list
 ```


### PR DESCRIPTION
* Do not install the acton repository signing key globally, only allow its use for the acton package repository.
* Change the distro to stable from bullseye.
* Append to acton.list to support both stable and tip releases